### PR TITLE
Feature .gitstrees

### DIFF
--- a/git-stree
+++ b/git-stree
@@ -315,18 +315,19 @@ function list_subtrees
 # Generate a syncing file for cross-repo syncing. Reads the --local .git/config file.
 function generate_sync_file() {
   local conf=$(git config --local -l)
+  local file=$(git rev-parse --show-toplevel)"/$SYNC_FNAME"
 
-  touch $SYNC_FNAME
-  echo -e '' > $SYNC_FNAME
+  touch $file
+  echo -e '' > $file
 
   for confline in $conf;
   do
     if [[ "$confline" == "remote.stree-"* ]]; then
       IFS='=' read key val <<< "$confline"
-      git config --file="$SYNC_FNAME" "$key" "$val"
+      git config --file="$file" "$key" "$val"
     elif [[ "$confline" == "stree."* ]]; then
       IFS='=' read key val <<< "$confline"
-      git config --file="$SYNC_FNAME" "$key" "$val"
+      git config --file="$file" "$key" "$val"
     fi
 
   done

--- a/git-stree
+++ b/git-stree
@@ -33,6 +33,9 @@
 { echo "foo" | iconv -t 'ASCII' &> /dev/null; } && has_iconv=true || has_iconv=false
 { echo "foo" | tr A-Z a-z &> /dev/null; } && has_tr=true || has_tr=false
 
+# Sync file name.
+SYNC_FNAME=".gitstrees"
+
 # Color constants (VT100 ANSI codes)
 CYAN=36
 GRAY=37
@@ -307,6 +310,28 @@ function list_subtrees
       echo ''
     fi
   done
+}
+
+# Generate a syncing file for cross-repo syncing. Reads the --local .git/config file.
+function generate_sync_file() {
+  local conf=$(git config --local -l)
+
+  touch $SYNC_FNAME
+  echo -e '' > $SYNC_FNAME
+
+  for confline in $conf;
+  do
+    if [[ "$confline" == "remote.stree-"* ]]; then
+      IFS='=' read key val <<< "$confline"
+      git config --file="$SYNC_FNAME" "$key" "$val"
+    elif [[ "$confline" == "stree."* ]]; then
+      IFS='=' read key val <<< "$confline"
+      git config --file="$SYNC_FNAME" "$key" "$val"
+    fi
+
+  done
+
+  meh "Strees configuration files synced!"
 }
 
 # Helper: info/success message.  This will show up in cyan on STDOUT.
@@ -692,8 +717,10 @@ case "$subcmd" in
     push_subtree;;
   r|rm)
     rm_subtree;;
-  s|sp|spl|spli|split)
+  sp|spl|spli|split)
     split_subtree;;
+  sy|syn|sync)
+    generate_sync_file;;
   ""|*)
     usage;;
 esac


### PR DESCRIPTION
Adds a function `generate_sync_file` that reads the `--local` git confguration file, parses for `stree` related keys and values, then outputs them to a `.gitattributes` -like config file in the same folder where `.git` folder sits in.

The config file is named `.gitstrees` and has the same git configuration structure that `git config ...` commands use.

Additionally adds CLI command `sync` that does the file generation.

No other functionalities, the application should continue to function normally, with the exception of `git stree s` no longer targeting `split` (at least `git stree sp` is needed as `sync` has been added).

**NOTE**: This function has been tested only on Linux Ubuntu 14.04 (and seemed to work fine).
