### PR TITLE
2 little bugfixes for git stree split

### DIFF
--- a/git-stree
+++ b/git-stree
@@ -336,13 +336,16 @@ function normalize_prefix
     echo "$1"
     return
   fi
-
-  local path="$(pwd -P)/$1"
-  path="${path//\/.\//\/}"
-  while [[ "$path"=~"([^/][^/]*/\.\./)" ]]; do
-    path="${path/${BASH_REMATCH[0]}/}"
-  done
-
+  if [ -n "`which readlink`" ]
+  then
+    local path=$(readlink -m $1)
+  else
+    local path="$(pwd -P)/$1"
+    path="${path//\/.\//\/}"
+    while [[ "$path"=~"([^/][^/]*/\.\./)" ]]; do
+      path="${path/${BASH_REMATCH[0]}/}"
+    done
+  fi
   sed "s@$root/@@" <<< "$path"
 }
 

--- a/git-stree
+++ b/git-stree
@@ -336,7 +336,13 @@ function normalize_prefix
     echo "$1"
     return
   fi
-  if [ -n "`which readlink`" ]
+
+  if [ -n `ls -1d "$1"` ]
+  then
+    pushd $1
+    local path=`pwd`
+    popd
+  elif [ -n "`which readlink`" ]
   then
     local path=$(readlink -m $1)
   else

--- a/git-stree
+++ b/git-stree
@@ -537,6 +537,7 @@ function split_subtree
     error false "A subtree backport branch already exists for '$name' ($branch_name).  Subtree already defined/split?"
   fi
 
+  pushd $(dirname $(git rev-parse --git-dir))
   git remote add -t "$branch" "$remote_name" "$url" &&
     git config --local "stree.$root_key.prefix" "$prefix" &&
     git config --local "stree.$root_key.branch" "$branch" &&
@@ -546,6 +547,7 @@ function split_subtree
     git config --local "stree.$root_key.latest-sync" "$(git rev-parse HEAD)" &&
     git checkout --quiet --merge "$latest_head" &&
     yay "STree '$root_key' configured, split and pushed."
+  popd
 }
 
 # Helper: usage display on STDERR.  Used when an error occurs or when the CLI


### PR DESCRIPTION
Hi, I just installed git-stree and start using it. How awesome !

Just found 2 little things I corrected in git stree split :
1) I first got an infinite loop.
For a reason I don't explain, the regexp match ~= always match, even where there is no .. in $path.
I replaced the loop with readlink

2) I got the git error "This command needs to be run in the root directory". So I encapsulate all with pushd/popd.
